### PR TITLE
Removes unused usage of `config('airlock.tokens', true)`

### DIFF
--- a/src/AirlockServiceProvider.php
+++ b/src/AirlockServiceProvider.php
@@ -91,7 +91,7 @@ class AirlockServiceProvider extends ServiceProvider
     protected function configureGuard()
     {
         Auth::resolved(function ($auth) {
-            $auth->viaRequest('airlock', new Guard($auth, config('airlock.tokens', true)));
+            $auth->viaRequest('airlock', new Guard($auth));
         });
     }
 


### PR DESCRIPTION
This pull request removes the usage of `config('airlock.tokens', true)` that apparently does not exists.