### PR TITLE
Remove hardcoded App\User model from Airlock.php in shouldRunMigratio…

### DIFF
--- a/src/Airlock.php
+++ b/src/Airlock.php
@@ -54,7 +54,7 @@ class Airlock
             return static::$runsMigrations;
         }
 
-        $model = config('auth.providers.users.model', 'App\\User');
+        $model = config('auth.providers.users.model', static::userModel());
 
         return class_exists($model)
                     ? in_array(HasApiTokens::class, class_uses_recursive($model))


### PR DESCRIPTION
i think by using **static::userModel()** this will keep fallback config consistent if someone used **useUserModel(SomeModel::class)**