### PR TITLE
use configured model first for userModel

### DIFF
--- a/src/Airlock.php
+++ b/src/Airlock.php
@@ -27,7 +27,7 @@ class Airlock
      */
     public static function userModel()
     {
-        return static::$userModel;
+        return config('auth.providers.users.model', static::$userModel);
     }
 
     /**
@@ -54,7 +54,7 @@ class Airlock
             return static::$runsMigrations;
         }
 
-        $model = config('auth.providers.users.model', static::userModel());
+        $model = static::userModel();
 
         return class_exists($model)
                     ? in_array(HasApiTokens::class, class_uses_recursive($model))


### PR DESCRIPTION
Without this change I always need to manually set the model that should be used with `Airlock::useUserModel(...)` instead of Airlock using the model that I have configured in the `config/auth.php` file.

After this change the `userModel` will either return the model from the configuration or the default that is defined on the class.