### PR TITLE
Remove unwanted expires_at from $casts & Pass expiration minutes to Gurad

### DIFF
--- a/src/AirlockServiceProvider.php
+++ b/src/AirlockServiceProvider.php
@@ -91,7 +91,7 @@ class AirlockServiceProvider extends ServiceProvider
     protected function configureGuard()
     {
         Auth::resolved(function ($auth) {
-            $auth->viaRequest('airlock', new Guard($auth));
+            $auth->viaRequest('airlock', new Guard($auth, config('airlock.expiration')));
         });
     }
 

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -14,7 +14,6 @@ class PersonalAccessToken extends Model
     protected $casts = [
         'abilities' => 'json',
         'last_used_at' => 'datetime',
-        'expires_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
this **PR** removes unwanted expires_at from $casts since the column has been removed . and also make sure to pass expiration minutes as second param to **Guard** cause all the tokens will be valid even if they expired