### PR TITLE
Add device_name to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The `tokenCan` method will always return `true` if the incoming authenticated re
 
 ### Authenticating Mobile Applications
 
-You may use Airlock tokens to authenticate your mobile application's requests to your API. To get started, create a route that accepts the user's email / username, password, and device_name, then exchanges them for a new Airlock token. You may then store the token on your device and use it to make additional API requests:
+You may use Airlock tokens to authenticate your mobile application's requests to your API. To get started, create a route that accepts the user's email / username, password, and device name, then exchanges them for a new Airlock token. You may then store the token on your device and use it to make additional API requests:
 
 ```php
 use App\User;

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The `tokenCan` method will always return `true` if the incoming authenticated re
 
 ### Authenticating Mobile Applications
 
-You may use Airlock tokens to authenticate your mobile application's requests to your API. To get started, create a route that accepts the user's email / username and password and exchanges them for a new Airlock token. You may then store the token on your device and use it to make additional API requests:
+You may use Airlock tokens to authenticate your mobile application's requests to your API. To get started, create a route that accepts the user's email / username, password, and device_name, then exchanges them for a new Airlock token. You may then store the token on your device and use it to make additional API requests:
 
 ```php
 use App\User;
@@ -137,7 +137,8 @@ use Illuminate\Validation\ValidationException;
 Route::post('/airlock/token', function (Request $request) {
     $request->validate([
         'email' => 'required|email',
-        'password' => 'required'
+        'password' => 'required',
+        'device_name' => 'required'
     ]);
 
     $user = User::where('email', $request->email)->first();


### PR DESCRIPTION
In the example for Authenticating Mobile Applications, the `$request` object references `device_name` when creating the token; however, the `validate` method does not ensure this value is present.

To address this, I required `device_name` to be present in the `$request` object, which I suspect would be a suitable solution.

Hope this helps!