### PR TITLE
Fix custom user model

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -44,7 +44,7 @@ class Guard
     public function __invoke(Request $request)
     {
         if ($user = $this->auth->guard('web')->user()) {
-            return $this->supportsTokens()
+            return $this->supportsTokens($user)
                         ? $user->withAccessToken(new TransientToken)
                         : $user;
         }
@@ -69,12 +69,13 @@ class Guard
     /**
      * Determine if the user model supports API tokens.
      *
+     * @param \Illuminate\Contracts\Auth\Authenticatable|null $user
      * @return bool
      */
-    protected function supportsTokens()
+    protected function supportsTokens($user = null)
     {
         return in_array(HasApiTokens::class, class_uses_recursive(
-            $this->auth->guard('web')->getProvider()->getModel()
+            $user ? get_class($user) : Airlock::userModel()
         ));
     }
 }

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -49,7 +49,6 @@ class GuardTest extends TestCase
                 ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn($fakeUser = new User);
-        $webGuard->shouldReceive('getProvider->getModel')->once()->andReturn(User::class);
 
         $user = $guard->__invoke(Request::create('/', 'GET'));
 
@@ -59,6 +58,8 @@ class GuardTest extends TestCase
 
     public function test_authentication_is_attempted_with_token_if_no_session_present()
     {
+        Airlock::useUserModel(User::class);
+
         $this->artisan('migrate', ['--database' => 'testbench'])->run();
 
         $factory = Mockery::mock(AuthFactory::class);
@@ -72,7 +73,6 @@ class GuardTest extends TestCase
                 ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
-        $webGuard->shouldReceive('getProvider->getModel')->andReturn(User::class);
 
         $request = Request::create('/', 'GET');
         $request->headers->set('Authorization', 'Bearer test');
@@ -100,7 +100,6 @@ class GuardTest extends TestCase
                 ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
-        $webGuard->shouldReceive('getProvider->getModel')->andReturn(User::class);
 
         $request = Request::create('/', 'GET');
         $request->headers->set('Authorization', 'Bearer test');
@@ -142,7 +141,6 @@ class GuardTest extends TestCase
                 ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
-        $webGuard->shouldReceive('getProvider->getModel')->andReturn(User::class);
 
         $request = Request::create('/', 'GET');
         $request->headers->set('Authorization', 'Bearer test');


### PR DESCRIPTION
We were always using the `web` user model class for both session and token authentication (at `supportsTokens()`. For token authentication, we have to use Airlock's user model.

Fixes #26 