### PR TITLE
Add option to select which session driver to use

### DIFF
--- a/config/airlock.php
+++ b/config/airlock.php
@@ -30,4 +30,14 @@ return [
 
     'expiration' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to select which session driver should be used
+    |
+    */
+    'session_driver' => 'cookie'
+
 ];

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -16,7 +16,7 @@ class EnsureFrontendRequestsAreStateful
      */
     public function handle($request, $next)
     {
-        $this->configureSecureCookieSessions();
+        $this->configureSecureSessions();
 
         return (new Pipeline(app()))->send($request)->through(static::fromFrontend($request) ? [
             function ($request, $next) {
@@ -38,10 +38,10 @@ class EnsureFrontendRequestsAreStateful
      *
      * @return void
      */
-    protected function configureSecureCookieSessions()
+    protected function configureSecureSessions()
     {
         config([
-            'session.driver' => 'cookie',
+            'session.driver' => config('airlock.session_driver', 'cookie'),
             'session.http_only' => true,
             'session.same_site' => 'lax',
         ]);


### PR DESCRIPTION
Currently for serverless applications where the cookie option is not available, subsequent requests using airlock do not work as the session driver is changed to cookie. This allows the user to specify which session driver should be used for subsequent requests.