### PR TITLE
Modify PersonalAccessToken Model to be polymorphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Within your web application's UI, you may wish to list each of the user's tokens
 
 ## Customization
 
-You may customize the "user" model and the personal access token model used by Airlock via the `useUserModel` and `usePersonalAccessTokenModel` methods. Typically, you should call these methods from the `boot` method of your `AppServiceProvider`:
+You may customize the the personal access token model used by Airlock via the `usePersonalAccessTokenModel` methods. Typically, you should call this method from the `boot` method of your `AppServiceProvider`:
 
 ```php
 use App\Airlock\CustomPersonalAccessToken;
@@ -184,8 +184,6 @@ use Laravel\Airlock\Airlock;
 
 public function boot()
 {
-    Airlock::useUserModel(CustomUser::class);
-
     Airlock::usePersonalAccessTokenModel(
         CustomPersonalAccessToken::class
     );

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -15,7 +15,7 @@ class CreatePersonalAccessTokensTable extends Migration
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->morphs('model');
+            $table->morphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -15,7 +15,7 @@ class CreatePersonalAccessTokensTable extends Migration
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('user_id')->index();
+            $table->morphs('model');
             $table->string('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();

--- a/src/Airlock.php
+++ b/src/Airlock.php
@@ -7,13 +7,6 @@ use Laravel\Airlock\HasApiTokens;
 class Airlock
 {
     /**
-     * The user model that should be used.
-     *
-     * @var string
-     */
-    public static $userModel;
-
-    /**
      * The personal access client model class name.
      *
      * @var string
@@ -25,30 +18,7 @@ class Airlock
      *
      * @var bool
      */
-    public static $runsMigrations;
-
-    /**
-     * Get the name of the user model used by Airlock.
-     *
-     * @return string
-     */
-    public static function userModel()
-    {
-        return static::$userModel ?: config('auth.providers.users.model', 'App\\User');
-    }
-
-    /**
-     * Specify the user model that should be used.
-     *
-     * @param  string  $model
-     * @return static
-     */
-    public static function useUserModel(string $model)
-    {
-        static::$userModel = $model;
-
-        return new static;
-    }
+    public static $runsMigrations = true;
 
     /**
      * Set the personal access token model name.
@@ -68,15 +38,7 @@ class Airlock
      */
     public static function shouldRunMigrations()
     {
-        if (! is_null(static::$runsMigrations)) {
-            return static::$runsMigrations;
-        }
-
-        $model = static::userModel();
-
-        return class_exists($model)
-                    ? in_array(HasApiTokens::class, class_uses_recursive($model))
-                    : true;
+       return static::$runsMigrations;
     }
 
     /**

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -49,7 +49,7 @@ class Guard
                         : $user;
         }
 
-        if ($this->supportsTokens() && $token = $request->bearerToken()) {
+        if ($token = $request->bearerToken()) {
             $model = Airlock::$personalAccessTokenModel;
 
             $accessToken = $model::where('token', hash('sha256', $token))->first();
@@ -60,9 +60,9 @@ class Guard
                 return;
             }
 
-            return $accessToken->user->withAccessToken(
+            return $this->supportsTokens($accessToken->user) ? $accessToken->user->withAccessToken(
                 tap($accessToken->forceFill(['last_used_at' => now()]))->save()
-            );
+            ) : null;
         }
     }
 
@@ -75,7 +75,7 @@ class Guard
     protected function supportsTokens($user = null)
     {
         return in_array(HasApiTokens::class, class_uses_recursive(
-            $user ? get_class($user) : Airlock::userModel()
+            $user ? get_class($user) : null
         ));
     }
 }

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -60,22 +60,22 @@ class Guard
                 return;
             }
 
-            return $this->supportsTokens($accessToken->user) ? $accessToken->user->withAccessToken(
+            return $this->supportsTokens($accessToken->tokenable) ? $accessToken->tokenable->withAccessToken(
                 tap($accessToken->forceFill(['last_used_at' => now()]))->save()
             ) : null;
         }
     }
 
     /**
-     * Determine if the user model supports API tokens.
+     * Determine if the tokenable model supports API tokens.
      *
      * @param \Illuminate\Contracts\Auth\Authenticatable|null $user
      * @return bool
      */
-    protected function supportsTokens($user = null)
+    protected function supportsTokens($tokenable = null)
     {
         return in_array(HasApiTokens::class, class_uses_recursive(
-            $user ? get_class($user) : null
+            $tokenable ? get_class($tokenable) : null
         ));
     }
 }

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -18,7 +18,7 @@ trait HasApiTokens
      */
     public function tokens()
     {
-        return $this->hasMany(Airlock::$personalAccessTokenModel);
+        return $this->morphMany(Airlock::$personalAccessTokenModel, 'model');
     }
 
     /**

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -14,11 +14,11 @@ trait HasApiTokens
     protected $accessToken;
 
     /**
-     * Get the access tokens that belong to the user.
+     * Get the access tokens that belong to model.
      */
     public function tokens()
     {
-        return $this->morphMany(Airlock::$personalAccessTokenModel, 'model');
+        return $this->morphMany(Airlock::$personalAccessTokenModel, 'tokenable');
     }
 
     /**

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -42,7 +42,7 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public function user()
     {
-        return $this->belongsTo(Airlock::userModel());
+        return $this->morphTo('model');
     }
 
     /**

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -38,11 +38,11 @@ class PersonalAccessToken extends Model implements HasAbilities
     ];
 
     /**
-     * Get the user that the access token belongs to.
+     * Get the tokenable model that the access token belongs to.
      */
-    public function user()
+    public function tokenable()
     {
-        return $this->morphTo('model');
+        return $this->morphTo('tokenable');
     }
 
     /**

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -107,8 +107,8 @@ class GuardTest extends TestCase
         ]);
 
         $token = PersonalAccessToken::forceCreate([
-            'model_id' => $user->id,
-            'model_type' => get_class($user),
+            'tokenable_id' => $user->id,
+            'tokenable_type' => get_class($user),
             'name' => 'Test',
             'token' => hash('sha256', 'test'),
             'created_at' => now()->subMinutes(60),
@@ -148,8 +148,8 @@ class GuardTest extends TestCase
         ]);
 
         $token = PersonalAccessToken::forceCreate([
-            'model_id' => $user->id,
-            'model_type' => get_class($user),
+            'tokenable_id' => $user->id,
+            'tokenable_type' => get_class($user),
             'name' => 'Test',
             'token' => hash('sha256', 'test'),
         ]);

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use Laravel\Airlock\Airlock;
 use Laravel\Airlock\AirlockServiceProvider;
 use Laravel\Airlock\Guard;
 use Laravel\Airlock\HasApiTokens;
@@ -58,8 +57,6 @@ class GuardTest extends TestCase
 
     public function test_authentication_is_attempted_with_token_if_no_session_present()
     {
-        Airlock::useUserModel(User::class);
-
         $this->artisan('migrate', ['--database' => 'testbench'])->run();
 
         $factory = Mockery::mock(AuthFactory::class);
@@ -84,8 +81,6 @@ class GuardTest extends TestCase
 
     public function test_authentication_with_token_fails_if_expired()
     {
-        Airlock::useUserModel(User::class);
-
         $this->loadLaravelMigrations(['--database' => 'testbench']);
         $this->artisan('migrate', ['--database' => 'testbench'])->run();
 
@@ -112,7 +107,8 @@ class GuardTest extends TestCase
         ]);
 
         $token = PersonalAccessToken::forceCreate([
-            'user_id' => $user->id,
+            'model_id' => $user->id,
+            'model_type' => get_class($user),
             'name' => 'Test',
             'token' => hash('sha256', 'test'),
             'created_at' => now()->subMinutes(60),
@@ -125,7 +121,6 @@ class GuardTest extends TestCase
 
     public function test_authentication_is_successful_with_token_if_no_session_present()
     {
-        Airlock::useUserModel(User::class);
 
         $this->loadLaravelMigrations(['--database' => 'testbench']);
         $this->artisan('migrate', ['--database' => 'testbench'])->run();
@@ -153,7 +148,8 @@ class GuardTest extends TestCase
         ]);
 
         $token = PersonalAccessToken::forceCreate([
-            'user_id' => $user->id,
+            'model_id' => $user->id,
+            'model_type' => get_class($user),
             'name' => 'Test',
             'token' => hash('sha256', 'test'),
         ]);


### PR DESCRIPTION
this **PR** resolves #10 . 

by making **PersonalAccessToken** model polymorphic will allow multiple models to be authenticated through airlock tokens .

for example if i have **Pharmacist** & **Doctor** models .  and would authenticate both of them through api  . i would have to [implement this solution](https://github.com/laravel/airlock/issues/10#issuecomment-573019653) which is in my opinion a little bit  tedious .

but by making **PersonalAccessToken** model polymorphic. this will allow implementing the above use case without any extra boilerplate . 

and also customization to user Model through **userModel()** won't be needed any more . cause polymorphic relation will support any other models .