### PR TITLE
Added user mocking through Airlock using actingAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ public function boot()
 
 ## Testing
 
-Similar to [Laravel Passport](https://laravel.com/docs/6.x/passport#testing), this method may be used to specify the currently authenticated user.
+While testing, the `Airlock::actingAs` method may be used to authenticate a user and specify which abilities are granted to their token:
 
 ```php
 use App\User;
 use Laravel\Airlock\Airlock;
 
-public function testingTaskList()
+public function test_task_list_can_be_retrieved()
 {
     Airlock::actingAs(
         factory(User::class)->create(),
@@ -209,6 +209,15 @@ public function testingTaskList()
 
     $response->assertOk();
 }
+```
+
+If you would like to grant all abilities to the token, you should include `*` in your ability list:
+
+```php
+Airlock::actingAs(
+    factory(User::class)->create(),
+    ['*']
+);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -190,6 +190,27 @@ public function boot()
 }
 ```
 
+## Testing
+
+Similar to [Laravel Passport](https://laravel.com/docs/6.x/passport#testing), this method may be used to specify the currently authenticated user.
+
+```php
+use App\User;
+use Laravel\Airlock\Airlock;
+
+public function testingTaskList()
+{
+    Airlock::actingAs(
+        factory(User::class)->create(),
+        ['view-tasks']
+    );
+
+    $response = $this->get('/api/task');
+
+    $response->assertOk();
+}
+```
+
 ## Contributing
 
 Thank you for considering contributing to Airlock! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/src/Airlock.php
+++ b/src/Airlock.php
@@ -22,10 +22,10 @@ class Airlock
     public static $runsMigrations = true;
 
     /**
-     * Set the current user for the application with the given scopes.
+     * Set the current user for the application with the given abilities.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|\Laravel\Passport\HasApiTokens  $user
-     * @param  array  $scopes
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|\Laravel\Airlock\HasApiTokens  $user
+     * @param  array  $abilities
      * @param  string  $guard
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */

--- a/src/Airlock.php
+++ b/src/Airlock.php
@@ -29,7 +29,7 @@ class Airlock
      * @param  string  $guard
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
-    public static function actingAs($user, $abilities = [], $guard = 'api')
+    public static function actingAs($user, $abilities = [], $guard = 'airlock')
     {
         $token = Mockery::mock(self::personalAccessTokenModel())->shouldIgnoreMissing(false);
 

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Airlock\Tests\Feature;
+
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Foundation\Auth\User;
+use Laravel\Airlock\Airlock;
+use Laravel\Airlock\HasApiTokens;
+use Orchestra\Testbench\TestCase;
+
+class ActingAsTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+
+    public function testActingAsWhenTheRouteIsProtectedByAuthMiddlware()
+    {
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/foo', function () {
+            return 'bar';
+        })->middleware('auth:api');
+
+        Airlock::actingAs(new AirlockUser());
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+
+    public function testActingAsWhenTheRouteIsProtectedUsingAbilities()
+    {
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $this->withoutExceptionHandling();
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('/foo', function () {
+            if (auth()->user()->tokenCan('baz')) {
+                return 'bar';
+            }
+
+            return response(403);
+        })->middleware('auth:api');
+
+        $user = new AirlockUser();
+        $user->createToken('test-token', ['baz'])->plainTextToken;
+
+        Airlock::actingAs($user);
+
+        $response = $this->get('/foo');
+        $response->assertSuccessful();
+        $response->assertSee('bar');
+    }
+}
+
+class AirlockUser extends User
+{
+    use HasApiTokens;
+}

--- a/tests/Feature/ActingAsTest.php
+++ b/tests/Feature/ActingAsTest.php
@@ -30,7 +30,7 @@ class ActingAsTest extends TestCase
 
         $router->get('/foo', function () {
             return 'bar';
-        })->middleware('auth:api');
+        })->middleware('auth:airlock');
 
         Airlock::actingAs(new AirlockUser());
 
@@ -54,7 +54,7 @@ class ActingAsTest extends TestCase
             }
 
             return response(403);
-        })->middleware('auth:api');
+        })->middleware('auth:airlock');
 
         $user = new AirlockUser();
         $user->createToken('test-token', ['baz'])->plainTextToken;


### PR DESCRIPTION
This pull request should resolve issue #50 by adding the requested functionality.

## Added

- `Airlock::actingAs` with tests for `auth:api` and abilities