### PR TITLE
Add CSRF middleware config

### DIFF
--- a/config/airlock.php
+++ b/config/airlock.php
@@ -30,4 +30,15 @@ return [
 
     'expiration' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | CSRF Middleware Class
+    |--------------------------------------------------------------------------
+    |
+    | TBD
+    |
+    */
+
+    'csrfMiddleware' => App\Http\Middleware\VerifyCsrfToken::class,
+
 ];

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -27,7 +27,7 @@ class EnsureFrontendRequestsAreStateful
             \Illuminate\Cookie\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+            config('airlock.csrfMiddleware', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class),
         ] : [])->then(function ($request) use ($next) {
             return $next($request);
         });


### PR DESCRIPTION
As explained in #53 , using Laravel Airlock is blocking from using a custom `VerifyCsrfToken` middleware.
So I added a `csrfMiddleware` config variable. I'm very bad with the description stuff, can you guys help me with that?