### PR TITLE
Allow .env configuration of airlock stateful domains (Take 2)

### DIFF
--- a/config/airlock.php
+++ b/config/airlock.php
@@ -13,10 +13,7 @@ return [
     |
     */
 
-    'stateful' => [
-        'localhost',
-        explode(',', env('AIRLOCK_STATEFUL_DOMAINS', ''))
-    ],
+    'stateful' => explode(',', env('AIRLOCK_STATEFUL_DOMAINS', 'localhost')),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/airlock.php
+++ b/config/airlock.php
@@ -15,6 +15,7 @@ return [
 
     'stateful' => [
         'localhost',
+        explode(',', env('AIRLOCK_STATEFUL_DOMAINS', ''))
     ],
 
     /*


### PR DESCRIPTION
Whilst `localhost` is a good default setting, for APIs that are installed in multiple environments (dev, test, prod) it is sensible to allow each environment to configure its stateful Airlock domains via the .env file (or alternative approaches e.g. AWS Elastic Beanstalk Configuration).