### PR TITLE
[1.x] Allow localhost ip access by default

### DIFF
--- a/config/airlock.php
+++ b/config/airlock.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('AIRLOCK_STATEFUL_DOMAINS', 'localhost')),
+    'stateful' => explode(',', env('AIRLOCK_STATEFUL_DOMAINS', 'localhost,127.0.0.1')),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Currently the airlock middleware blocks requests from 127.0.0.1 by default only allowing the use localhost itself. This may lead to confusion to certain users especially since if you use artisan serve it recommends the use of 127.0.0.1:8000.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
