### PR TITLE
Use the API Guard to get the Authenticated User

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -42,7 +42,7 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard('web')->user()) {
+        if ($user = $this->auth->guard('api')->user()) {
             return $this->supportsTokens($user)
                         ? $user->withAccessToken(new TransientToken)
                         : $user;


### PR DESCRIPTION
Currently I can authenticate successfully by sending a get request to '/airlock/csrf-cookie' the logging in the normal way, but subsequent requests are returning a 401 response with a message of "Unauthenticated". My debugging has led to this change – switching the guard from 'web' to 'api' is authenticated user.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
