### PR TITLE
[1.x] Using the Default Guard Defined in the Auth Config

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -42,7 +42,7 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard('web')->user()) {
+        if ($user = $this->auth->guard(config('auth.default.guard', 'web'))->user()) {
             return $this->supportsTokens($user)
                         ? $user->withAccessToken(new TransientToken)
                         : $user;


### PR DESCRIPTION
Currently the default guard can be changed but we hard code the web guard in this case, changing it to a dynamic definition of the name still allows us to change the config. If this poses some issues we need to update the documentation and state that the default must be set to 'web'.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
