### PR TITLE
[1.x] Updates composer dependency 6.0 => 6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "illuminate/contracts": "^6.0|^7.0",
-        "illuminate/database": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/contracts": "^6.9|^7.0",
+        "illuminate/database": "^6.9|^7.0",
+        "illuminate/support": "^6.9|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Updates composer dependency 6.0.0 to 6.9.0 to resolve the package throwing an error if used with earlier versions than 6.9.0 as detailed in Feature Request #88 