### PR TITLE
Add support for all subdomains

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -54,11 +54,11 @@ class EnsureFrontendRequestsAreStateful
      */
     public static function fromFrontend($request)
     {
-        $referer = Str::replaceFirst('https://', '', $request->headers->get('referer'));
+        $url = \parse_url($request->headers->get('referer'));
 
-        $referer = Str::replaceFirst('http://', '', $referer);
+        $referer = $url['host'];
 
-        return Str::startsWith(
+        return Str::endsWith(
             $referer,
             config('airlock.stateful', [])
         );

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -22,7 +22,17 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
 
         $request = Request::create('/');
+        $request->headers->set('referer', 'https://subdomain.test.com');
+
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
         $request->headers->set('referer', 'https://wrong.com');
+
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
+        $request->headers->set('referer', 'https://wrong.com.test.com');
 
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -32,7 +32,7 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
 
         $request = Request::create('/');
-        $request->headers->set('referer', 'https://wrong.com.test.com');
+        $request->headers->set('referer', 'https://test.com.wrong.com');
 
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }


### PR DESCRIPTION
There is currently not a way to accept all subdomains when setting `AIRLOCK_STATEFUL_DOMAINS `. We are building an application where cookies on the root domain should work on all subdomains. This PR changes the logic to allow for that scenario.

I considered making it a config option to allow subdomains, but I could not think of any negative consequences by making this the default behavior.
