### PR TITLE
Wildcard Stateful Config

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -60,6 +60,10 @@ class EnsureFrontendRequestsAreStateful
 
         $stateful = config('airlock.stateful', []);
 
-        return $stateful === '*' || Str::startsWith($referer, $stateful);
+        if (strpos($stateful, '*.') === 0) {
+            return Str::startsWith(strstr($referer, '.'), strstr($stateful, '.'));
+        }
+
+        return Str::startsWith($referer, $stateful);
     }
 }

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -58,9 +58,8 @@ class EnsureFrontendRequestsAreStateful
 
         $referer = Str::replaceFirst('http://', '', $referer);
 
-        return Str::startsWith(
-            $referer,
-            config('airlock.stateful', [])
-        );
+        $stateful = config('airlock.stateful', []);
+
+        return $stateful === '*' || Str::startsWith($referer, $stateful);
     }
 }

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -9,13 +9,10 @@ use Orchestra\Testbench\TestCase;
 
 class EnsureFrontendRequestsAreStatefulTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('airlock.stateful', 'test.com');
-    }
-
     public function test_request_referer_is_parsed_against_configuration()
     {
+        config()->set('airlock.stateful', 'test.com');
+
         $request = Request::create('/');
         $request->headers->set('referer', 'https://test.com');
 
@@ -25,6 +22,21 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $request->headers->set('referer', 'https://wrong.com');
 
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+    }
+
+    public function test_request_referer_is_parsed_against_wildcard_configuration()
+    {
+        config()->set('airlock.stateful', '*');
+
+        $request = Request::create('/');
+        $request->headers->set('referer', 'https://test.com');
+
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
+        $request->headers->set('referer', 'https://wrong.com');
+
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 
     protected function getPackageProviders($app)

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -22,21 +22,36 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $request->headers->set('referer', 'https://wrong.com');
 
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
+        $request->headers->set('referer', 'https://subdomain.test.com');
+
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 
-    public function test_request_referer_is_parsed_against_wildcard_configuration()
+    public function test_request_referer_allows_subdomains()
     {
-        config()->set('airlock.stateful', '*');
+        config()->set('airlock.stateful', '*.test.com');
 
         $request = Request::create('/');
         $request->headers->set('referer', 'https://test.com');
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
 
         $request = Request::create('/');
         $request->headers->set('referer', 'https://wrong.com');
 
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
+        $request->headers->set('referer', 'https://subdomain.test.com');
+
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
+        $request->headers->set('referer', 'https://subdomain.subdomain.test.com');
+
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
I have a case where whitelisting specific domains isn't practical. For example services like [Zeit](https://zeit.co/) deploy development branches with unique `xxxxxxxx.company.now.sh` domain names. It would be nice if there was a way to define a wildcard.